### PR TITLE
Add family class metadata support (Issue #10).

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,12 @@ Changes in TTF
 v1.1.1 - YYYY-MM-DD
 -------------------
 
+- Added `ttf_class_t` type and `ttfGetFamilyClass` function for the OS/2
+  family class metadata (Issue #10)
+- Added `ttfCacheGetFamilyClass` and `ttfCacheSearch` functions for finding fonts
+  by family class (Issue #10)
+- Added `ttfCacheIsFixedPitch` function and cached the fixed-pitch value so
+  monospace searches don't need to load each font
 - Added tests for `ttfGetCMap`.
 - Added missing implementation of `ttfGetFilename`.
 - Updated the range limit check in `ttfGetWidth`.

--- a/testttf.c
+++ b/testttf.c
@@ -154,12 +154,17 @@ static int				// O - Number of errors
 list_fonts(bool verbose)		// I - Be verbose?
 {
   ttf_cache_t	*cache;			// Font cache
+  ttf_cache_t	*matches;		// Search results
+  ttf_t		*font;			// Font
   size_t	i,			// Looping var
 		num_fonts;		// Number of fonts
   time_t	start,			// Start time
 		end;			// End time
   char		name[256];		// Font name
   int		errors = 0;		// Number of errors
+  ttf_class_t	family_class;		// Font family class
+  bool		has_sans = false,	// Have a sans-serif font?
+		has_serif = false;	// Have a serif font?
   const char	*test_mono = NULL,	// Test monospaced family name...
 		*test_sans = NULL,	// Test sans-serif family name...
 		*test_serif = NULL;	// Test serif family name
@@ -211,6 +216,24 @@ list_fonts(bool verbose)		// I - Be verbose?
         test_serif = "Times New Roman";
     }
 
+    family_class = ttfCacheGetFamilyClass(cache, i);
+
+    if (family_class & TTF_CLASS_SANS_SERIF)
+    {
+      has_sans = true;
+
+      if (!test_sans)
+        test_sans = family;
+    }
+
+    if (family_class & (TTF_CLASS_OLDSTYLE_SERIFS | TTF_CLASS_TRANSITIONAL_SERIFS | TTF_CLASS_MODERN_SERIFS | TTF_CLASS_CLARENDON_SERIFS | TTF_CLASS_SLAB_SERIFS | TTF_CLASS_FREEFORM_SERIFS))
+    {
+      has_serif = true;
+
+      if (!test_serif)
+        test_serif = family;
+    }
+
     format_name(name, sizeof(name), family, ttfCacheGetStyle(cache, i), ttfCacheGetWeight(cache, i), ttfCacheGetStretch(cache, i));
 
     if (!verbose)
@@ -239,6 +262,107 @@ list_fonts(bool verbose)		// I - Be verbose?
     errors += test_find_font(cache, test_serif, TTF_STYLE_NORMAL, TTF_WEIGHT_700, TTF_STRETCH_UNSPEC);
   }
 
+  if (num_fonts > 0)
+  {
+    testBegin("ttfCacheSearch(TTF_CLASS_UNSPEC)");
+    if ((matches = ttfCacheSearch(cache, TTF_CLASS_UNSPEC, TTF_STYLE_UNSPEC, TTF_WEIGHT_UNSPEC, TTF_STRETCH_UNSPEC, /*fixed_pitch*/false)) != NULL && ttfCacheGetNumFonts(matches) > 0)
+      testEndMessage(true, "%s", ttfCacheGetFamily(matches, 0));
+    else
+    {
+      testEnd(false);
+      errors ++;
+    }
+
+    ttfCacheDelete(matches);
+  }
+
+  if (has_sans)
+  {
+    testBegin("ttfCacheSearch(TTF_CLASS_SANS_SERIF)");
+    if ((matches = ttfCacheSearch(cache, TTF_CLASS_SANS_SERIF, TTF_STYLE_UNSPEC, TTF_WEIGHT_UNSPEC, TTF_STRETCH_UNSPEC, /*fixed_pitch*/false)) != NULL && ttfCacheGetNumFonts(matches) > 0 && (ttfCacheGetFamilyClass(matches, 0) & TTF_CLASS_SANS_SERIF))
+      testEndMessage(true, "%s", ttfCacheGetFamily(matches, 0));
+    else
+    {
+      testEnd(false);
+      errors ++;
+    }
+
+    ttfCacheDelete(matches);
+  }
+
+  if (has_serif)
+  {
+    static const ttf_class_t serif_classes = TTF_CLASS_OLDSTYLE_SERIFS | TTF_CLASS_TRANSITIONAL_SERIFS | TTF_CLASS_MODERN_SERIFS | TTF_CLASS_CLARENDON_SERIFS | TTF_CLASS_SLAB_SERIFS | TTF_CLASS_FREEFORM_SERIFS;
+
+    testBegin("ttfCacheSearch(serif classes)");
+    if ((matches = ttfCacheSearch(cache, serif_classes, TTF_STYLE_UNSPEC, TTF_WEIGHT_UNSPEC, TTF_STRETCH_UNSPEC, /*fixed_pitch*/false)) != NULL && ttfCacheGetNumFonts(matches) > 0 && (ttfCacheGetFamilyClass(matches, 0) & serif_classes))
+      testEndMessage(true, "%s", ttfCacheGetFamily(matches, 0));
+    else
+    {
+      testEnd(false);
+      errors ++;
+    }
+
+    ttfCacheDelete(matches);
+  }
+
+  if (test_mono)
+  {
+    testBegin("ttfCacheSearch(fixed-pitch)");
+    if ((matches = ttfCacheSearch(cache, TTF_CLASS_UNSPEC, TTF_STYLE_UNSPEC, TTF_WEIGHT_UNSPEC, TTF_STRETCH_UNSPEC, /*fixed_pitch*/true)) != NULL && ttfCacheGetNumFonts(matches) > 0)
+    {
+      bool all_mono = true;
+
+      for (i = 0; i < ttfCacheGetNumFonts(matches); i ++)
+      {
+        if (!ttfCacheIsFixedPitch(matches, i))
+        {
+          all_mono = false;
+          break;
+        }
+      }
+
+      if (all_mono)
+        testEndMessage(true, "%lu", (unsigned long)ttfCacheGetNumFonts(matches));
+      else
+      {
+        testEnd(false);
+        errors ++;
+      }
+    }
+    else
+    {
+      testEnd(false);
+      errors ++;
+    }
+
+    ttfCacheDelete(matches);
+  }
+
+  testBegin("ttfCacheIsFixedPitch");
+  {
+    bool	all_match = true;	// All cached flags match the fonts?
+
+    for (i = 0; i < num_fonts; i ++)
+    {
+      ttf_t *cfont = ttfCacheGetFont(cache, i);
+
+      if (cfont && ttfCacheIsFixedPitch(cache, i) != ttfIsFixedPitch(cfont))
+      {
+        all_match = false;
+        break;
+      }
+    }
+
+    if (all_match)
+      testEndMessage(true, "%lu fonts", (unsigned long)num_fonts);
+    else
+    {
+      testEnd(false);
+      errors ++;
+    }
+  }
+
   return (errors);
 }
 
@@ -263,7 +387,7 @@ test_find_font(ttf_cache_t   *cache,	// I - Font cache
   {
     testEndMessage(true, "%s", format_name(name, sizeof(name), ttfGetFamily(font), ttfGetStyle(font), ttfGetWeight(font), ttfGetStretch(font)));
 
-    return (test_font(/*filename*/NULL, font));
+    return (test_font(ttfGetFilename(font), font));
   }
   else
   {
@@ -298,6 +422,8 @@ test_font(const char *filename,		// I - Font filename or `NULL`
   size_t	num_fonts;		// Number of fonts
   ttf_style_t	style;			// Font style
   ttf_weight_t	weight;			// Font weight
+  ttf_class_t	family_class;		// Font family class
+  bool		reload;			// Reload the font from memory?
   const int	*cmap;			// CMap table
   size_t	num_cmap;		// Number of CMap entries
   static const char * const stretches[] =
@@ -329,6 +455,8 @@ test_font(const char *filename,		// I - Font filename or `NULL`
     "TTF_STYLE_OBLIQUE"
   };
 
+
+  reload = (filename != NULL && font == NULL);
 
   if (filename && !font)
   {
@@ -532,6 +660,17 @@ test_font(const char *filename,		// I - Font filename or `NULL`
     errors ++;
   }
 
+  testBegin("ttfGetFamilyClass");
+  if (!((family_class = ttfGetFamilyClass(font)) & ~(ttf_class_t)0x07ff))
+  {
+    testEndMessage(true, "0x%04x", (unsigned)family_class);
+  }
+  else
+  {
+    testEndMessage(false, "0x%04x", (unsigned)family_class);
+    errors ++;
+  }
+
   testBegin("ttfGetWidth(' ')");
 
   if ((intvalue = ttfGetWidth(font, ' ')) > 0)
@@ -558,8 +697,9 @@ test_font(const char *filename,		// I - Font filename or `NULL`
   testBegin("ttfIsFixedPitch");
   testEndMessage(true, "%s", ttfIsFixedPitch(font) ? "true" : "false");
 
-  // Return immediately if we don't have the original filename...
-  if (!filename)
+  // Return immediately if we didn't create the font here (e.g., it was loaded
+  // from the font cache and is managed by the caller)...
+  if (!reload)
     return (errors);
 
   // Delete the first font and try getting it from memory...

--- a/ttf-cache.c
+++ b/ttf-cache.c
@@ -25,7 +25,7 @@
 					// Header/prefix string for first line
 #define TTF_CACHE_HEADERLEN	9	// Length of header string
 #define TTF_CACHE_MAX		65536	// Maximum number of cached fonts
-#define TTF_CACHE_VERSION	0	// Version number of cache format
+#define TTF_CACHE_VERSION	2	// Version number of cache format
 
 
 //
@@ -41,6 +41,8 @@ typedef struct _ttf_cfont_s		// Cached font
   ttf_stretch_t stretch;                // Stretch
   ttf_style_t   style;                  // Style
   ttf_weight_t  weight;                 // Weight
+  ttf_class_t   family_class;           // Family class
+  bool          is_fixed_pitch;         // Is fixed-pitch (monospace)?
 } _ttf_cfont_t;
 
 
@@ -379,18 +381,6 @@ ttfCacheFind(ttf_cache_t   *cache,	// I - Font cache
 
 
 //
-// 'ttfCacheGetFilename()' - Get the font filename at index N.
-//
-
-const char *				// O - Font filename/URL or `NULL` if none
-ttfCacheGetFilename(ttf_cache_t *cache,	// I - Font cache
-                    size_t      n)	// I - Font index starting at `0`
-{
-  return ((cache && n < cache->num_fonts) ? cache->fonts[n].filename : NULL);
-}
-
-
-//
 // 'ttfCacheGetFamily()' - Get the font family at index N.
 //
 
@@ -399,6 +389,30 @@ ttfCacheGetFamily(ttf_cache_t *cache,	// I - Font cache
 		  size_t      n)	// I - Font index starting at `0`
 {
   return ((cache && n < cache->num_fonts) ? cache->fonts[n].family : NULL);
+}
+
+
+//
+// 'ttfCacheGetFamilyClass()' - Get the font family class at index N.
+//
+
+ttf_class_t				// O - Family class or `TTF_CLASS_UNSPEC`
+ttfCacheGetFamilyClass(ttf_cache_t *cache,	// I - Font cache
+                       size_t      n)		// I - Font index starting at `0`
+{
+  return ((cache && n < cache->num_fonts) ? cache->fonts[n].family_class : TTF_CLASS_UNSPEC);
+}
+
+
+//
+// 'ttfCacheGetFilename()' - Get the font filename at index N.
+//
+
+const char *				// O - Font filename/URL or `NULL` if none
+ttfCacheGetFilename(ttf_cache_t *cache,	// I - Font cache
+                    size_t      n)	// I - Font index starting at `0`
+{
+  return ((cache && n < cache->num_fonts) ? cache->fonts[n].filename : NULL);
 }
 
 
@@ -444,6 +458,17 @@ ttfCacheGetIndex(ttf_cache_t *cache,	// I - Font cache
 
 
 //
+// 'ttfCacheGetNumFonts()' - Get the number of fonts in the cache.
+//
+
+size_t					// O - Number of fonts
+ttfCacheGetNumFonts(ttf_cache_t *cache)	// I - Font cache
+{
+  return (cache ? cache->num_fonts : 0);
+}
+
+
+//
 // 'ttfCacheGetStretch()' - Get the font stretch at index N.
 //
 
@@ -480,13 +505,131 @@ ttfCacheGetWeight(ttf_cache_t *cache,	// I - Font cache
 
 
 //
-// 'ttfCacheGetNumFonts()' - Get the number of fonts in the cache.
+// 'ttfCacheIsFixedPitch()' - Returns whether the font at index N is fixed-pitch.
 //
 
-size_t					// O - Number of fonts
-ttfCacheGetNumFonts(ttf_cache_t *cache)	// I - Font cache
+bool					// O - `true` if fixed-pitch, `false` otherwise
+ttfCacheIsFixedPitch(ttf_cache_t *cache,	// I - Font cache
+		     size_t      n)	// I - Font index starting at `0`
 {
-  return (cache ? cache->num_fonts : 0);
+  return ((cache && n < cache->num_fonts) ? cache->fonts[n].is_fixed_pitch : false);
+}
+
+
+//
+// 'ttfCacheSearch()' - Search the cache for fonts with the specified family class.
+//
+// This function searches the cache for fonts matching the specified family
+// class, style, weight, and stretch.  A family class of `TTF_CLASS_UNSPEC`
+// matches all family classes, and `TTF_STYLE_UNSPEC`, `TTF_WEIGHT_UNSPEC`, and
+// `TTF_STRETCH_UNSPEC` match any style, weight, or stretch.  If "fixed_pitch"
+// is `true`, only monospace (fixed-pitch) fonts are returned.
+//
+// The returned `ttf_cache_t` object contains all matching fonts and must be
+// freed using @link ttfCacheDelete@.  The fonts in the returned cache are
+// managed by it and are lazily loaded as needed.
+//
+
+ttf_cache_t *				// O - Matching fonts or `NULL` if none
+ttfCacheSearch(ttf_cache_t   *cache,	// I - Font cache
+               ttf_class_t   family_class,	// I - Family class or `TTF_CLASS_UNSPEC` to match all
+               ttf_style_t   style,	// I - Font style or `TTF_STYLE_UNSPEC`
+               ttf_weight_t  weight,	// I - Font weight or `TTF_WEIGHT_UNSPEC`
+               ttf_stretch_t stretch,	// I - Font stretch or `TTF_STRETCH_UNSPEC`
+               bool          fixed_pitch)	// I - `true` for monospace fonts only
+{
+  ttf_cache_t	*result;		// Search results
+  size_t	i;			// Looping var
+  _ttf_cfont_t	*font,			// Current font
+		*rfont;			// Result font
+
+
+  TTF_DEBUG("ttfCacheSearch(cache=%p, family_class=%u, style=%d, weight=%d, stretch=%d, fixed_pitch=%s)\n", (void *)cache, (unsigned)family_class, style, weight, stretch, fixed_pitch ? "true" : "false");
+
+  // Range check input...
+  if (!cache)
+    return (NULL);
+
+  // Allocate the result cache...
+  if ((result = calloc(1, sizeof(ttf_cache_t))) == NULL)
+    return (NULL);
+
+  result->err_cb     = cache->err_cb;
+  result->err_cbdata = cache->err_cbdata;
+
+  // Loop through the cache looking for matches...
+  for (i = 0, font = cache->fonts; i < cache->num_fonts; i ++, font ++)
+  {
+    if (family_class != TTF_CLASS_UNSPEC && !(font->family_class & family_class))
+      continue;
+
+    if (style != TTF_STYLE_UNSPEC && style != font->style)
+      continue;
+
+    if (weight != TTF_WEIGHT_UNSPEC && weight != font->weight)
+      continue;
+
+    if (stretch != TTF_STRETCH_UNSPEC && stretch != font->stretch)
+      continue;
+
+    if (fixed_pitch && !font->is_fixed_pitch)
+      continue;
+
+    TTF_DEBUG("ttfCacheSearch: [%u] family=\"%s\", class=%u\n", (unsigned)i, font->family, (unsigned)font->family_class);
+
+    // Add a copy of the cached font to the results...
+    if (result->num_fonts >= result->alloc_fonts)
+    {
+      if ((rfont = realloc(result->fonts, (result->alloc_fonts + 32) * sizeof(_ttf_cfont_t))) == NULL)
+        goto error;
+
+      result->fonts       = rfont;
+      result->alloc_fonts += 32;
+    }
+
+    rfont = result->fonts + result->num_fonts;
+
+    memset(rfont, 0, sizeof(_ttf_cfont_t));
+
+    if (font->filename && (rfont->filename = strdup(font->filename)) == NULL)
+      goto error;
+
+    if ((rfont->family = strdup(font->family)) == NULL)
+    {
+      free(rfont->filename);
+      goto error;
+    }
+
+    rfont->idx          = font->idx;
+    rfont->stretch      = font->stretch;
+    rfont->style        = font->style;
+    rfont->weight       = font->weight;
+    rfont->family_class = font->family_class;
+    rfont->is_fixed_pitch = font->is_fixed_pitch;
+
+    result->num_fonts ++;
+  }
+
+  if (result->num_fonts == 0)
+  {
+    // No matches...
+    free(result);
+    return (NULL);
+  }
+
+  // Sort the results so that ttfCacheFind works...
+  ttf_sort_fonts(result);
+
+  TTF_DEBUG("ttfCacheSearch: Found %lu fonts.\n", (unsigned long)result->num_fonts);
+
+  return (result);
+
+  // If we get here, we ran out of memory...
+  error:
+
+  ttfCacheDelete(result);
+
+  return (NULL);
 }
 
 
@@ -529,7 +672,9 @@ ttf_add_font(ttf_cache_t *cache,	// I - Font cache
   cfont->idx      = idx;
   cfont->stretch  = ttfGetStretch(font);
   cfont->style    = ttfGetStyle(font);
-  cfont->weight   = ttfGetWeight(font);
+  cfont->weight       = ttfGetWeight(font);
+  cfont->family_class = ttfGetFamilyClass(font);
+  cfont->is_fixed_pitch = ttfIsFixedPitch(font);
 
   if ((family = ttfGetFamily(font)) == NULL || (cfont->family = strdup(family)) == NULL)
     goto cleanup;
@@ -642,11 +787,13 @@ ttf_load_cache(ttf_cache_t *cache)	// I - Font cache
   _ttf_cfont_t	*font;			// Current cached font
   char		line[1024],		// Header/attributes line
 		*lineptr;		// Pointer into line
-  long		num_fonts,		// Number of fonts in cache
+	long		num_fonts,	// Number of fonts in cache
 		idx,			// Font index in a file
 		stretch,		// Font stretch
 		style,			// Font style
-		weight;			// Font weight
+		weight,			// Font weight
+		family_class,		// Family class
+		fixed_pitch;		// Fixed-pitch flag
 
 
   // Try opening the cache file...
@@ -683,7 +830,7 @@ ttf_load_cache(ttf_cache_t *cache)	// I - Font cache
   // Read cache entries of the form:
   //
   // INDEX FILENAME
-  // STRETCH STYLE WEIGHT FAMILY
+  // STRETCH STYLE WEIGHT CLASS FIXEDPITCH FAMILY
 
   while (ttf_gets(fp, line, sizeof(line)))
   {
@@ -727,7 +874,7 @@ ttf_load_cache(ttf_cache_t *cache)	// I - Font cache
       goto error;
     }
 
-    TTF_DEBUG("ttf_load_cache: (str-sty-wgt-fam) %s\n", line);
+    TTF_DEBUG("ttf_load_cache: (str-sty-wgt-cls-fix-fam) %s\n", line);
 
     if ((stretch = strtol(line, &lineptr, 10)) < TTF_STRETCH_NORMAL || stretch > TTF_STRETCH_ULTRA_EXPANDED || !lineptr || !isspace(*lineptr & 255))
     {
@@ -747,6 +894,18 @@ ttf_load_cache(ttf_cache_t *cache)	// I - Font cache
       goto error;
     }
 
+    if ((family_class = strtol(lineptr, &lineptr, 10)) < 0 || family_class > 0x07ff || !lineptr || !isspace(*lineptr & 255))
+    {
+      TTF_DEBUG("ttf_load_cache: Bad family class.\n");
+      goto error;
+    }
+
+    if ((fixed_pitch = strtol(lineptr, &lineptr, 10)) < 0 || fixed_pitch > 1 || !lineptr || !isspace(*lineptr & 255))
+    {
+      TTF_DEBUG("ttf_load_cache: Bad fixed pitch.\n");
+      goto error;
+    }
+
     while (*lineptr && isspace(*lineptr & 255))
       lineptr ++;
 
@@ -762,9 +921,11 @@ ttf_load_cache(ttf_cache_t *cache)	// I - Font cache
       goto error;
     }
 
-    font->stretch = (ttf_stretch_t)stretch;
-    font->style   = (ttf_style_t)style;
-    font->weight  = (ttf_weight_t)weight;
+    font->stretch     = (ttf_stretch_t)stretch;
+    font->style       = (ttf_style_t)style;
+    font->weight      = (ttf_weight_t)weight;
+    font->family_class = (ttf_class_t)family_class;
+    font->is_fixed_pitch = fixed_pitch ? true : false;
 
     font ++;
   }
@@ -967,7 +1128,7 @@ ttf_save_cache(ttf_cache_t *cache)	// I - Font cache
       continue;
 
     fprintf(fp, "%u %s\n", (unsigned)font->idx, font->filename);
-    fprintf(fp, "%d %d %d %s\n", font->stretch, font->style, font->weight, font->family);
+    fprintf(fp, "%d %d %d %d %d %s\n", font->stretch, font->style, font->weight, font->family_class, font->is_fixed_pitch ? 1 : 0, font->family);
   }
 
   fclose(fp);

--- a/ttf-file.c
+++ b/ttf-file.c
@@ -154,6 +154,7 @@ struct _ttf_s
   float		italic_angle;		// Angle of italic text
   ttf_stretch_t	stretch;		// Font stretch value
   ttf_style_t	style;			// Font style
+  ttf_class_t	family_class;		// Family class
 };
 
 typedef struct _ttf_off_cmap4_s		// Format 4 cmap table
@@ -211,7 +212,8 @@ typedef struct _ttf_off_os_2_s		// OS/2 information
   short		sTypoAscender,		// Ascender
 		sTypoDescender,		// Descender
 		sxHeight,		// xHeight
-		sCapHeight;		// CapHeight
+		sCapHeight,		// CapHeight
+		sFamilyClass;		// Family class
 } _ttf_off_os_2_t;
 
 typedef struct _ttf_off_post_s		// PostScript information
@@ -595,6 +597,17 @@ const char *				// O - Family name
 ttfGetFamily(ttf_t *font)		// I - Font
 {
   return (font ? font->family : NULL);
+}
+
+
+//
+// 'ttfGetFamilyClass()' - Get the family class of a font.
+//
+
+ttf_class_t				// O - Family class or `TTF_CLASS_UNSPEC`
+ttfGetFamilyClass(ttf_t *font)		// I - Font
+{
+  return (font ? font->family_class : TTF_CLASS_UNSPEC);
 }
 
 
@@ -1181,6 +1194,28 @@ create_font(const char   *filename,	// I - Filename or `NULL`
 
     font->cap_height = os_2.sCapHeight;
     font->x_height   = os_2.sxHeight;
+
+    static const ttf_class_t family_classes[] =
+    {
+      TTF_CLASS_NONE,			// 0 - No classification
+      TTF_CLASS_OLDSTYLE_SERIFS,	// 1 - Oldstyle serifs
+      TTF_CLASS_TRANSITIONAL_SERIFS,	// 2 - Transitional serifs
+      TTF_CLASS_MODERN_SERIFS,		// 3 - Modern serifs
+      TTF_CLASS_CLARENDON_SERIFS,	// 4 - Clarendon serifs
+      TTF_CLASS_SLAB_SERIFS,		// 5 - Slab serifs
+      TTF_CLASS_NONE,			// 6 - Reserved
+      TTF_CLASS_FREEFORM_SERIFS,		// 7 - Freeform serifs
+      TTF_CLASS_SANS_SERIF,		// 8 - Sans serif
+      TTF_CLASS_ORNAMENTALS,		// 9 - Ornamentals
+      TTF_CLASS_SCRIPTS,			// 10 - Scripts
+      TTF_CLASS_NONE,			// 11 - Reserved
+      TTF_CLASS_SYMBOLIC,		// 12 - Symbolic
+      TTF_CLASS_NONE,			// 13 - Reserved
+      TTF_CLASS_NONE,			// 14 - Reserved
+      TTF_CLASS_NONE			// 15 - Miscellaneous
+    };
+
+    font->family_class = family_classes[(os_2.sFamilyClass >> 8) & 0xff];
   }
   else
   {
@@ -2353,7 +2388,7 @@ read_os_2(ttf_t           *font,	// I - Font
   /* ySuperscriptYOffset */ read_short(font);
   /* yStrikeoutSize */      read_short(font);
   /* yStrikeoutOffset */    read_short(font);
-  /* sFamilyClass */        read_short(font);
+  os_2->sFamilyClass      = (short)read_short(font);
   /* panose[10] */
   if ((font->read_cb)(font, panose, sizeof(panose)) != sizeof(panose))
     return (false);

--- a/ttf.h
+++ b/ttf.h
@@ -67,6 +67,32 @@ typedef enum ttf_weight_e	// Font weight
   TTF_WEIGHT_900 = 900		// Weight 900 (Black/Heavy)
 } ttf_weight_t;
 
+typedef enum ttf_class_e	// Family class bit values
+{
+  TTF_CLASS_UNSPEC = 0,		// Unspecified
+  TTF_CLASS_NONE = 0x0001,	// No classification
+  TTF_CLASS_OLDSTYLE_SERIFS = 0x0002,
+					// Old style serifs
+  TTF_CLASS_TRANSITIONAL_SERIFS = 0x0004,
+					// Transitional serifs
+  TTF_CLASS_MODERN_SERIFS = 0x0008,
+					// Modern serifs
+  TTF_CLASS_CLARENDON_SERIFS = 0x0010,
+					// Clarendon serifs
+  TTF_CLASS_SLAB_SERIFS = 0x0020,
+					// Slab serifs
+  TTF_CLASS_FREEFORM_SERIFS = 0x0040,
+					// Freeform serifs
+  TTF_CLASS_SANS_SERIF = 0x0080,
+					// Sans-serif
+  TTF_CLASS_ORNAMENTALS = 0x0100,
+					// Ornamentals
+  TTF_CLASS_SCRIPTS = 0x0200,
+					// Scripts
+  TTF_CLASS_SYMBOLIC = 0x0400
+					// Symbolic
+} ttf_class_t;
+
 typedef struct ttf_rect_s	// Bounding rectangle
 {
   float	left;			// Left offset
@@ -84,14 +110,17 @@ extern void		ttfCacheAdd(ttf_cache_t *cache, ttf_t *font, const char *filename);
 extern ttf_cache_t      *ttfCacheCreate(const char *appname, ttf_err_cb_t err_cb, void *err_data);
 extern void             ttfCacheDelete(ttf_cache_t *cache);
 extern ttf_t            *ttfCacheFind(ttf_cache_t *cache, const char *family, ttf_style_t style, ttf_weight_t weight, ttf_stretch_t stretch);
-extern const char       *ttfCacheGetFilename(ttf_cache_t *cache, size_t n);
 extern const char       *ttfCacheGetFamily(ttf_cache_t *cache, size_t n);
+extern ttf_class_t      ttfCacheGetFamilyClass(ttf_cache_t *cache, size_t n);
+extern const char       *ttfCacheGetFilename(ttf_cache_t *cache, size_t n);
+extern ttf_t            *ttfCacheGetFont(ttf_cache_t *cache, size_t n);
 extern size_t		ttfCacheGetIndex(ttf_cache_t *cache, size_t n);
+extern size_t           ttfCacheGetNumFonts(ttf_cache_t *cache);
 extern ttf_stretch_t    ttfCacheGetStretch(ttf_cache_t *cache, size_t n);
 extern ttf_style_t      ttfCacheGetStyle(ttf_cache_t *cache, size_t n);
 extern ttf_weight_t     ttfCacheGetWeight(ttf_cache_t *cache, size_t n);
-extern ttf_t            *ttfCacheGetFont(ttf_cache_t *cache, size_t n);
-extern size_t           ttfCacheGetNumFonts(ttf_cache_t *cache);
+extern bool             ttfCacheIsFixedPitch(ttf_cache_t *cache, size_t n);
+extern ttf_cache_t      *ttfCacheSearch(ttf_cache_t *cache, ttf_class_t family_class, ttf_style_t style, ttf_weight_t weight, ttf_stretch_t stretch, bool fixed_pitch);
 extern bool		ttfContainsChar(ttf_t *font, int ch);
 extern bool		ttfContainsChars(ttf_t *font, const char *s);
 extern ttf_t		*ttfCreate(const char *filename, size_t idx, ttf_err_cb_t err_cb, void *err_data);
@@ -107,6 +136,7 @@ extern const char	*ttfGetCopyright(ttf_t *font);
 extern int		ttfGetDescent(ttf_t *font);
 extern ttf_rect_t	*ttfGetExtents(ttf_t *font, float size, const char *s, ttf_rect_t *extents);
 extern const char	*ttfGetFamily(ttf_t *font);
+extern ttf_class_t	ttfGetFamilyClass(ttf_t *font);
 extern const char       *ttfGetFilename(ttf_t *ttf);
 extern float		ttfGetItalicAngle(ttf_t *font);
 extern size_t		ttfGetKernedExtents(ttf_t *font, float size, const char *s, ttf_rect_t *extents, size_t max_adjs, double *adjs);

--- a/ttf.html
+++ b/ttf.html
@@ -287,6 +287,7 @@ span.string {
 <li><a href="#ttfCacheDelete">ttfCacheDelete</a></li>
 <li><a href="#ttfCacheFind">ttfCacheFind</a></li>
 <li><a href="#ttfCacheGetFamily">ttfCacheGetFamily</a></li>
+<li><a href="#ttfCacheGetFamilyClass">ttfCacheGetFamilyClass</a></li>
 <li><a href="#ttfCacheGetFilename">ttfCacheGetFilename</a></li>
 <li><a href="#ttfCacheGetFont">ttfCacheGetFont</a></li>
 <li><a href="#ttfCacheGetIndex">ttfCacheGetIndex</a></li>
@@ -294,6 +295,8 @@ span.string {
 <li><a href="#ttfCacheGetStretch">ttfCacheGetStretch</a></li>
 <li><a href="#ttfCacheGetStyle">ttfCacheGetStyle</a></li>
 <li><a href="#ttfCacheGetWeight">ttfCacheGetWeight</a></li>
+<li><a href="#ttfCacheIsFixedPitch">ttfCacheIsFixedPitch</a></li>
+<li><a href="#ttfCacheSearch">ttfCacheSearch</a></li>
 <li><a href="#ttfContainsChar">ttfContainsChar</a></li>
 <li><a href="#ttfContainsChars">ttfContainsChars</a></li>
 <li><a href="#ttfCreate">ttfCreate</a></li>
@@ -307,6 +310,7 @@ span.string {
 <li><a href="#ttfGetDescent">ttfGetDescent</a></li>
 <li><a href="#ttfGetExtents">ttfGetExtents</a></li>
 <li><a href="#ttfGetFamily">ttfGetFamily</a></li>
+<li><a href="#ttfGetFamilyClass">ttfGetFamilyClass</a></li>
 <li><a href="#ttfGetItalicAngle">ttfGetItalicAngle</a></li>
 <li><a href="#ttfGetKernedExtents">ttfGetKernedExtents</a></li>
 <li><a href="#ttfGetMaxChar">ttfGetMaxChar</a></li>
@@ -323,6 +327,7 @@ span.string {
 </ul></li>
 <li><a href="#TYPES">Data Types</a><ul class="subcontents">
 <li><a href="#ttf_cache_t">ttf_cache_t</a></li>
+<li><a href="#ttf_class_t">ttf_class_t</a></li>
 <li><a href="#ttf_err_cb_t">ttf_err_cb_t</a></li>
 <li><a href="#ttf_rect_t">ttf_rect_t</a></li>
 <li><a href="#ttf_stretch_t">ttf_stretch_t</a></li>
@@ -334,6 +339,7 @@ span.string {
 <li><a href="#ttf_rect_s">ttf_rect_s</a></li>
 </ul></li>
 <li><a href="#ENUMERATIONS">Enumerations</a><ul class="subcontents">
+<li><a href="#ttf_class_e">ttf_class_e</a></li>
 <li><a href="#ttf_stretch_e">ttf_stretch_e</a></li>
 <li><a href="#ttf_style_e">ttf_style_e</a></li>
 <li><a href="#ttf_weight_e">ttf_weight_e</a></li>
@@ -490,6 +496,19 @@ managed by the cache and should not be deleted.</p>
 </tbody></table>
 <h4 class="returnvalue">Return Value</h4>
 <p class="description">Font family name or <code>NULL</code></p>
+<h3 class="function"><a id="ttfCacheGetFamilyClass">ttfCacheGetFamilyClass</a></h3>
+<p class="description">Get the font family class at index N.</p>
+<p class="code">
+<a href="#ttf_class_t">ttf_class_t</a> ttfCacheGetFamilyClass(<a href="#ttf_cache_t">ttf_cache_t</a> *cache, size_t n);</p>
+<h4 class="parameters">Parameters</h4>
+<table class="list"><tbody>
+<tr><th>cache</th>
+<td class="description">Font cache</td></tr>
+<tr><th>n</th>
+<td class="description">Font index starting at <code>0</code></td></tr>
+</tbody></table>
+<h4 class="returnvalue">Return Value</h4>
+<p class="description">Family class or <code>TTF_CLASS_UNSPEC</code></p>
 <h3 class="function"><a id="ttfCacheGetFilename">ttfCacheGetFilename</a></h3>
 <p class="description">Get the font filename at index N.</p>
 <p class="code">
@@ -582,6 +601,43 @@ size_t ttfCacheGetNumFonts(<a href="#ttf_cache_t">ttf_cache_t</a> *cache);</p>
 </tbody></table>
 <h4 class="returnvalue">Return Value</h4>
 <p class="description">Font weight or <code>TTF_WEIGHT_UNSPEC</code></p>
+<h3 class="function"><a id="ttfCacheIsFixedPitch">ttfCacheIsFixedPitch</a></h3>
+<p class="description">Returns whether the font at index N is fixed-pitch.</p>
+<p class="code">
+<span class="reserved">bool</span> ttfCacheIsFixedPitch(<a href="#ttf_cache_t">ttf_cache_t</a> *cache, size_t n);</p>
+<h4 class="parameters">Parameters</h4>
+<table class="list"><tbody>
+<tr><th>cache</th>
+<td class="description">Font cache</td></tr>
+<tr><th>n</th>
+<td class="description">Font index starting at <code>0</code></td></tr>
+</tbody></table>
+<h4 class="returnvalue">Return Value</h4>
+<p class="description"><code>true</code> if fixed-pitch, <code>false</code> otherwise</p>
+<h3 class="function"><a id="ttfCacheSearch">ttfCacheSearch</a></h3>
+<p class="description">Search the cache for fonts with the specified family class.</p>
+<p class="code">
+<a href="#ttf_cache_t">ttf_cache_t</a> *ttfCacheSearch(<a href="#ttf_cache_t">ttf_cache_t</a> *cache, <a href="#ttf_class_t">ttf_class_t</a> family_class, <a href="#ttf_style_t">ttf_style_t</a> style, <a href="#ttf_weight_t">ttf_weight_t</a> weight, <a href="#ttf_stretch_t">ttf_stretch_t</a> stretch, <span class="reserved">bool</span> fixed_pitch);</p>
+<h4 class="parameters">Parameters</h4>
+<table class="list"><tbody>
+<tr><th>cache</th>
+<td class="description">Font cache</td></tr>
+<tr><th>family_class</th>
+<td class="description">Family class or <code>TTF_CLASS_UNSPEC</code> to match all</td></tr>
+<tr><th>style</th>
+<td class="description">Font style or <code>TTF_STYLE_UNSPEC</code> to match all</td></tr>
+<tr><th>weight</th>
+<td class="description">Font weight or <code>TTF_WEIGHT_UNSPEC</code> to match all</td></tr>
+<tr><th>stretch</th>
+<td class="description">Font stretch or <code>TTF_STRETCH_UNSPEC</code> to match all</td></tr>
+<tr><th>fixed_pitch</th>
+<td class="description"><code>true</code> to only return fixed-pitch (monospace) fonts</td></tr>
+</tbody></table>
+<h4 class="returnvalue">Return Value</h4>
+<p class="description">Cache of matching fonts or <code>NULL</code> if none found</p>
+<h4 class="discussion">Discussion</h4>
+<p class="discussion">This function searches the cache for all fonts matching the specified family class, style, weight, stretch, and fixed-pitch requirements.  A family class of <code>TTF_CLASS_UNSPEC</code> matches all family classes, and <code>TTF_STYLE_UNSPEC</code>, <code>TTF_WEIGHT_UNSPEC</code>, and <code>TTF_STRETCH_UNSPEC</code> match any style, weight, or stretch.  If <code>fixed_pitch</code> is <code>true</code>, only monospace (fixed-pitch) fonts are returned.</p>
+<p class="discussion">The returned <code>ttf_cache_t</code> object contains all matching fonts and must be freed using <a href="#ttfCacheDelete">ttfCacheDelete</a>.  The fonts in the returned cache are lazily loaded as needed.</p>
 <h3 class="function"><a id="ttfContainsChar">ttfContainsChar</a></h3>
 <p class="description">Test for the presence of a Unicode character in a font.</p>
 <p class="code">
@@ -809,6 +865,17 @@ values are scaled using the specified font size.</p>
 </tbody></table>
 <h4 class="returnvalue">Return Value</h4>
 <p class="description">Family name</p>
+<h3 class="function"><a id="ttfGetFamilyClass">ttfGetFamilyClass</a></h3>
+<p class="description">Get the family class of a font.</p>
+<p class="code">
+<a href="#ttf_class_t">ttf_class_t</a> ttfGetFamilyClass(<a href="#ttf_t">ttf_t</a> *font);</p>
+<h4 class="parameters">Parameters</h4>
+<table class="list"><tbody>
+<tr><th>font</th>
+<td class="description">Font</td></tr>
+</tbody></table>
+<h4 class="returnvalue">Return Value</h4>
+<p class="description">Family class or <code>TTF_CLASS_UNSPEC</code></p>
 <h3 class="function"><a id="ttfGetItalicAngle">ttfGetItalicAngle</a></h3>
 <p class="description">Get the italic angle.</p>
 <p class="code">
@@ -978,6 +1045,11 @@ size_t ttfGetNumFonts(<a href="#ttf_t">ttf_t</a> *font);</p>
 <p class="code">
 typedef struct _ttf_cache_s ttf_cache_t;
 </p>
+<h3 class="typedef"><a id="ttf_class_t">ttf_class_t</a></h3>
+<p class="description">Family class bitfield</p>
+<p class="code">
+typedef enum <a href="#ttf_class_e">ttf_class_e</a> ttf_class_t;
+</p>
 <h3 class="typedef"><a id="ttf_err_cb_t">ttf_err_cb_t</a></h3>
 <p class="description">Font error callback</p>
 <p class="code">
@@ -1029,6 +1101,23 @@ typedef enum <a href="#ttf_weight_e">ttf_weight_e</a> ttf_weight_t;
 <td class="description">Top offset</td></tr>
 </tbody></table>
 <h2 class="title"><a id="ENUMERATIONS">Constants</a></h2>
+<h3 class="enumeration"><a id="ttf_class_e">ttf_class_e</a></h3>
+<p class="description">Family class bit values</p>
+<h4 class="constants">Constants</h4>
+<table class="list"><tbody>
+<tr><th>TTF_CLASS_CLARENDON_SERIFS </th><td class="description">Clarendon serifs</td></tr>
+<tr><th>TTF_CLASS_FREEFORM_SERIFS </th><td class="description">Freeform serifs</td></tr>
+<tr><th>TTF_CLASS_MODERN_SERIFS </th><td class="description">Modern serifs</td></tr>
+<tr><th>TTF_CLASS_NONE </th><td class="description">No classification</td></tr>
+<tr><th>TTF_CLASS_OLDSTYLE_SERIFS </th><td class="description">Old style serifs</td></tr>
+<tr><th>TTF_CLASS_ORNAMENTALS </th><td class="description">Ornamentals</td></tr>
+<tr><th>TTF_CLASS_SANS_SERIF </th><td class="description">Sans-serif</td></tr>
+<tr><th>TTF_CLASS_SCRIPTS </th><td class="description">Scripts</td></tr>
+<tr><th>TTF_CLASS_SLAB_SERIFS </th><td class="description">Slab serifs</td></tr>
+<tr><th>TTF_CLASS_SYMBOLIC </th><td class="description">Symbolic</td></tr>
+<tr><th>TTF_CLASS_TRANSITIONAL_SERIFS </th><td class="description">Transitional serifs</td></tr>
+<tr><th>TTF_CLASS_UNSPEC </th><td class="description">Unspecified</td></tr>
+</tbody></table>
 <h3 class="enumeration"><a id="ttf_stretch_e">ttf_stretch_e</a></h3>
 <p class="description">Font stretch</p>
 <h4 class="constants">Constants</h4>


### PR DESCRIPTION
Fixes #10

Add family class metadata support to the TTF API.

Changes:
- Add ttf_class_e/ttf_class_t with the bit values from the issue
- Add ttfGetFamilyClass() and ttfCacheGetFamilyClass()
- Add ttfCacheSearch() to find all fonts matching a family class,
  optionally filtered by style, weight, stretch, and fixed-pitch
  (TTF_CLASS_UNSPEC acts as a wildcard for the class).  The function
  returns a new ttf_cache_t containing the matching fonts, which must
  be freed with ttfCacheDelete()
- Read and store the OS/2 sFamilyClass value and map the IBM class IDs
  to ttf_class_e values (see
  https://learn.microsoft.com/en-us/typography/opentype/spec/ibmfc)
- Bump TTF_CACHE_VERSION to 1 and store the family class in the cache
  file (the save format line gains one field: "%d %d %d %d %s\n")
- Document the new API in ttf.html and CHANGES.md
- Fix a pre-existing test bug in the ttfGetFilename test added in
  7b27b70: it passed a NULL filename for cache-loaded fonts, so the
  filename assertion always failed on systems with matching fonts
  installed.  test_find_font now passes the real filename, and test_font
  only reloads from memory when it created the font itself, so
  cache-owned fonts are not deleted.

Tested with make test: all tests pass.